### PR TITLE
Handle a case where if a voice fails to start we deal

### DIFF
--- a/include/sst/voicemanager/managers/polymanager.h
+++ b/include/sst/voicemanager/managers/polymanager.h
@@ -113,7 +113,7 @@ template <typename Cfg, typename Responder> struct PolyManager
             return true;
 
         /*
-        if(voicesLaunched + something > somethingElse)
+        if(voicesToBeLaunched + something > somethingElse)
         {
             TODO: Stealing. Probably want this before the create loop too.
         }
@@ -121,8 +121,9 @@ template <typename Cfg, typename Responder> struct PolyManager
 
         auto voicesLaunched = responder.initializeMultipleVoices(
             voiceInitWorkingBuffer, port, channel, key, noteid, velocity, retune);
-        if (voicesLaunched == voicesToBeLaunched)
+        if (voicesLaunched != voicesToBeLaunched)
         {
+            return false;
         }
 
         auto voicesLeft = voicesLaunched;


### PR DESCRIPTION
Previously if voices created didn't match expected in the poly manager the release would point at corrupted memroy. Do a simple fix of that for now, but still no voice stealing in place