### PR TITLE
Move to begin/end transaction around voice initiation

### DIFF
--- a/include/sst/voicemanager/managers/polymanager.h
+++ b/include/sst/voicemanager/managers/polymanager.h
@@ -107,10 +107,13 @@ template <typename Cfg, typename Responder> struct PolyManager
         }
 
         auto voicesToBeLaunched =
-            responder.voiceCountForInitializationAction(port, channel, key, noteid, velocity);
+            responder.beginVoiceCreationTransaction(port, channel, key, noteid, velocity);
 
         if (voicesToBeLaunched == 0)
+        {
+            responder.endVoiceCreationTransaction(port, channel, key, noteid, velocity);
             return true;
+        }
 
         /*
         if(voicesToBeLaunched + something > somethingElse)
@@ -158,9 +161,15 @@ template <typename Cfg, typename Responder> struct PolyManager
                 }
                 voicesLeft--;
                 if (voicesLeft == 0)
+                {
+                    responder.endVoiceCreationTransaction(port, channel, key, noteid, velocity);
+
                     return true;
+                }
             }
         }
+
+        responder.endVoiceCreationTransaction(port, channel, key, noteid, velocity);
 
         return false;
     }

--- a/tests/basic_poly.cpp
+++ b/tests/basic_poly.cpp
@@ -61,11 +61,14 @@ struct ConcreteResp
     void retriggerVoiceWithNewNoteID(void *v, int32_t noteid, float velocity) {}
 
     void setVoiceMIDIPitchBend(void *v, uint16_t) {}
-    int voiceCountForInitializationAction(uint16_t port, uint16_t channel, uint16_t key,
+    int beginVoiceCreationTransaction(uint16_t port, uint16_t channel, uint16_t key,
                                           int32_t noteid, float velocity)
     {
         return 1;
     }
+    void endVoiceCreationTransaction(uint16_t port, uint16_t channel, uint16_t key,
+                                          int32_t noteid, float velocity)
+    {}
 
     // Innards
     struct Innards

--- a/tests/basic_poly.cpp
+++ b/tests/basic_poly.cpp
@@ -61,14 +61,15 @@ struct ConcreteResp
     void retriggerVoiceWithNewNoteID(void *v, int32_t noteid, float velocity) {}
 
     void setVoiceMIDIPitchBend(void *v, uint16_t) {}
-    int beginVoiceCreationTransaction(uint16_t port, uint16_t channel, uint16_t key,
-                                          int32_t noteid, float velocity)
+    int beginVoiceCreationTransaction(uint16_t port, uint16_t channel, uint16_t key, int32_t noteid,
+                                      float velocity)
     {
         return 1;
     }
-    void endVoiceCreationTransaction(uint16_t port, uint16_t channel, uint16_t key,
-                                          int32_t noteid, float velocity)
-    {}
+    void endVoiceCreationTransaction(uint16_t port, uint16_t channel, uint16_t key, int32_t noteid,
+                                     float velocity)
+    {
+    }
 
     // Innards
     struct Innards


### PR DESCRIPTION
This changes the responder API somewhat from count voices / make voices to begin transaction / make voices / end transaction with the guarantee that we will not begin another transaction until end is called. This allows responders to share internal state over the voice creation while still allowing the manager a chance to steal etc... although it does change the public API of the responder.