### PR TITLE
Fix a missing keybed update in legato mode

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: pick GCC12
+        if: runner.os == 'Linux'
+        run: |
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 12
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 12
+
       - name: Build test
         run: |
           cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release -DSST_VOICEMANAGER_BUILD_TESTS=TRUE 

--- a/tests/test_player.h
+++ b/tests/test_player.h
@@ -28,6 +28,7 @@
 #include <map>
 
 #include "sst/voicemanager/voicemanager.h"
+#include <algorithm>
 
 #define TPT(...)                                                                                   \
     if constexpr (doLog)                                                                           \
@@ -290,18 +291,17 @@ template <size_t voiceCount, bool doLog = false> struct TestPlayer
         MonoResponder(TestPlayer &p) : testPlayer(p) {}
         void setMIDIPitchBend(int16_t channel, int16_t pb14bit)
         {
-            assert(channel >= 0 && channel < 16);
-            testPlayer.pitchBend[channel] = pb14bit;
+            testPlayer.pitchBend[std::clamp(channel, (int16_t)0, (int16_t)15)] = pb14bit;
         }
         void setMIDI1CC(int16_t channel, int16_t cc, int8_t val)
         {
             assert(channel >= 0 && channel < 16);
-            testPlayer.midi1CC[channel][cc] = val;
+            testPlayer.midi1CC[std::clamp(channel, (int16_t)0, (int16_t)15)][cc] = val;
         }
         void setMIDIChannelPressure(int16_t channel, int16_t pres)
         {
             assert(channel >= 0 && channel < 16);
-            testPlayer.channelPressure[channel] = pres;
+            testPlayer.channelPressure[std::clamp(channel, (int16_t)0, (int16_t)15)] = pres;
         }
     } monoResponder;
 

--- a/tests/test_player.h
+++ b/tests/test_player.h
@@ -290,14 +290,17 @@ template <size_t voiceCount, bool doLog = false> struct TestPlayer
         MonoResponder(TestPlayer &p) : testPlayer(p) {}
         void setMIDIPitchBend(int16_t channel, int16_t pb14bit)
         {
+            assert(channel >=0 && channel < 16);
             testPlayer.pitchBend[channel] = pb14bit;
         }
         void setMIDI1CC(int16_t channel, int16_t cc, int8_t val)
         {
+            assert(channel >=0 && channel < 16);
             testPlayer.midi1CC[channel][cc] = val;
         }
         void setMIDIChannelPressure(int16_t channel, int16_t pres)
         {
+            assert(channel >=0 && channel < 16);
             testPlayer.channelPressure[channel] = pres;
         }
     } monoResponder;

--- a/tests/test_player.h
+++ b/tests/test_player.h
@@ -290,17 +290,17 @@ template <size_t voiceCount, bool doLog = false> struct TestPlayer
         MonoResponder(TestPlayer &p) : testPlayer(p) {}
         void setMIDIPitchBend(int16_t channel, int16_t pb14bit)
         {
-            assert(channel >=0 && channel < 16);
+            assert(channel >= 0 && channel < 16);
             testPlayer.pitchBend[channel] = pb14bit;
         }
         void setMIDI1CC(int16_t channel, int16_t cc, int8_t val)
         {
-            assert(channel >=0 && channel < 16);
+            assert(channel >= 0 && channel < 16);
             testPlayer.midi1CC[channel][cc] = val;
         }
         void setMIDIChannelPressure(int16_t channel, int16_t pres)
         {
-            assert(channel >=0 && channel < 16);
+            assert(channel >= 0 && channel < 16);
             testPlayer.channelPressure[channel] = pres;
         }
     } monoResponder;


### PR DESCRIPTION
In legato mode when no voice was created the keybed was mis-recorded, leading to inconsistent triggering when legatoing across an ungated phase, and in some cases, inconsistent retriggering