### PR TITLE
Fix a systain pedal coherence problem

### DIFF
--- a/tests/piano_mode.cpp
+++ b/tests/piano_mode.cpp
@@ -111,3 +111,11 @@ TEST_CASE("Poly Multi Key Non Piano Mode")
         REQUIRE_VOICE_COUNTS(3, 3);
     }
 }
+/*
+TEST_CASE("Piano Mode Sustain Pedal")
+{
+    SECTION("Multile notes, no retrig, sustain") { REQUIRE_INCOMPLETE_TEST; }
+
+    SECTION("Retrigger a note under sustain") { REQUIRE_INCOMPLETE_TEST; }
+}
+*/


### PR DESCRIPTION
In MIDI1 mode, susteain on was omni, sustain off was channel pegged, and so you could get stuck notes easily with channel mixes. Make it so MIDI1 uses channel-of-note sustain and MPE uses channel-0 sustain

First fix for https://github.com/baconpaul/six-sines/issues/88