### PR TITLE
Expand test coverage for lifecycle and group limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+.claude/
 .DS_Store
 .idea/
 cmake-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if (DEFINED SST_VOICEMANAGER_BUILD_TESTS)
 endif()
 if (PROJECT_IS_TOP_LEVEL)
   set(bldtest TRUE)
+  if (USE_RTSAN)
+    add_compile_options(-fsanitize=realtime)
+    add_compile_definitions(USE_RTSAN=TRUE)
+    add_link_options(-fsanitize=realtime)
+  endif()
 endif()
 
 if (MSVC)
@@ -36,6 +41,7 @@ if (${bldtest})
             tests/piano_mode.cpp
             tests/midi1_to_vm.cpp
             tests/note_ids.cpp
+            tests/note_on_return.cpp
             tests/voice_ids.cpp
             tests/continuation_data.cpp
             tests/multi_port.cpp

--- a/include/sst/voicemanager/voicemanager.h
+++ b/include/sst/voicemanager/voicemanager.h
@@ -247,6 +247,7 @@ template <typename Cfg, typename Responder, typename MonoResponder> struct Voice
 
     void guaranteeGroup(uint64_t groupId);
     void setPolyphonyGroupVoiceLimit(uint64_t groupId, int32_t limit);
+    [[nodiscard]] int32_t getPolyphonyGroupVoiceLimit(uint64_t groupId) const;
     void setPlaymode(uint64_t groupId, PlayMode pm,
                      uint64_t features = static_cast<uint64_t>(MonoPlayModeFeatures::NONE));
     void setStealingPriorityMode(uint64_t groupId, StealingPriorityMode pm);

--- a/include/sst/voicemanager/voicemanager_impl.h
+++ b/include/sst/voicemanager/voicemanager_impl.h
@@ -1434,7 +1434,18 @@ void VoiceManager<Cfg, Responder, MonoResponder>::setPolyphonyGroupVoiceLimit(ui
                                                                               int32_t limit)
 {
     details.guaranteeGroup(groupId);
-    details.polyLimits[groupId] = limit;
+    // A limit below 1 or above the physical pool is meaningless; clamp rather than reject
+    details.polyLimits[groupId] = std::clamp(limit, 1, static_cast<int32_t>(Cfg::maxVoiceCount));
+}
+
+template <typename Cfg, typename Responder, typename MonoResponder>
+int32_t
+VoiceManager<Cfg, Responder, MonoResponder>::getPolyphonyGroupVoiceLimit(uint64_t groupId) const
+{
+    auto it = details.polyLimits.find(groupId);
+    if (it == details.polyLimits.end())
+        return static_cast<int32_t>(Cfg::maxVoiceCount);
+    return it->second;
 }
 
 template <typename Cfg, typename Responder, typename MonoResponder>

--- a/tests/basic_poly.cpp
+++ b/tests/basic_poly.cpp
@@ -159,6 +159,29 @@ TEST_CASE("Basic Poly Note On Note Off")
     }
 }
 
+TEST_CASE("Retune Parameter Reaches Voice")
+{
+    INFO("The 6th arg of processNoteOnEvent (retune) is forwarded to initializeMultipleVoices "
+         "and must arrive verbatim on the created voice.");
+
+    TestPlayer<32> tp;
+    auto &vm = tp.voiceManager;
+    REQUIRE_NO_VOICES;
+
+    vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.37f);
+    REQUIRE_VOICE_COUNTS(1, 1);
+    REQUIRE(tp.activeVoiceCheck([](auto &v) { return v.key() == 60; },
+                                [](auto &v) { return v.retune == 0.37f; }));
+
+    // A second note with a different (negative) retune; the first voice is unaffected
+    vm.processNoteOnEvent(0, 0, 64, -1, 0.8f, -1.5f);
+    REQUIRE_VOICE_COUNTS(2, 2);
+    REQUIRE(tp.activeVoiceCheck([](auto &v) { return v.key() == 64; },
+                                [](auto &v) { return v.retune == -1.5f; }));
+    REQUIRE(tp.activeVoiceCheck([](auto &v) { return v.key() == 60; },
+                                [](auto &v) { return v.retune == 0.37f; }));
+}
+
 TEST_CASE("Sustain Pedal")
 {
     SECTION("Pedal Down Pre Note")
@@ -297,6 +320,51 @@ TEST_CASE("AllNotesOff")
     REQUIRE_VOICE_COUNTS(8, 0);
 }
 
+TEST_CASE("AllNotesOff Releases Sustained And Mono Voices")
+{
+    SECTION("Sustain-Held Voices Are Released")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        REQUIRE_NO_VOICES;
+
+        vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f);
+        vm.processNoteOnEvent(0, 0, 64, -1, 0.8f, 0.f);
+        vm.updateSustainPedal(0, 0, 127);
+        vm.processNoteOffEvent(0, 0, 60, -1, 0.2f);
+        // 60 is now held only by sustain, so it is still counted as gated
+        REQUIRE_VOICE_COUNTS(2, 2);
+
+        vm.allNotesOff();
+        // Both voices ungate, including the sustain-held one
+        REQUIRE_VOICE_COUNTS(2, 0);
+
+        tp.processFor(10);
+        REQUIRE_NO_VOICES;
+    }
+
+    SECTION("Mono Voice Is Released")
+    {
+        using vm_t = TestPlayer<32>::voiceManager_t;
+        using MF = vm_t::MonoPlayModeFeatures;
+
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        vm.setPlaymode(0, vm_t::PlayMode::MONO_NOTES, (uint64_t)MF::NATURAL_MONO);
+        REQUIRE_NO_VOICES;
+
+        vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f);
+        vm.processNoteOnEvent(0, 0, 64, -1, 0.8f, 0.f); // mono: still one voice
+        REQUIRE_VOICE_COUNTS(1, 1);
+
+        vm.allNotesOff();
+        REQUIRE_VOICE_COUNTS(1, 0);
+
+        tp.processFor(10);
+        REQUIRE_NO_VOICES;
+    }
+}
+
 TEST_CASE("AllSoundsOff")
 {
     TestPlayer<32> tp;
@@ -392,6 +460,55 @@ TEST_CASE("AllSoundsOffMatching")
 
         REQUIRE_VOICE_COUNTS(1, 1);
         REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 62; }) == 1);
+    }
+}
+
+TEST_CASE("AllSoundsOff Mono Mode")
+{
+    using vm_t = TestPlayer<32>::voiceManager_t;
+    using MF = vm_t::MonoPlayModeFeatures;
+
+    SECTION("Terminates The Mono Voice And Does Not Resurrect On Release")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        vm.setPlaymode(0, vm_t::PlayMode::MONO_NOTES, (uint64_t)MF::NATURAL_LEGATO);
+        REQUIRE_NO_VOICES;
+
+        // Two keys held; legato mono collapses to a single voice
+        vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f);
+        vm.processNoteOnEvent(0, 0, 64, -1, 0.8f, 0.f);
+        REQUIRE_VOICE_COUNTS(1, 1);
+
+        vm.allSoundsOff();
+        REQUIRE_NO_VOICES;
+
+        // allSoundsOff terminates instantly, so releasing a still-"held" key must
+        // not retrigger a fresh voice from the leftover held-key state
+        vm.processNoteOffEvent(0, 0, 64, -1, 0.2f);
+        REQUIRE_NO_VOICES;
+        vm.processNoteOffEvent(0, 0, 60, -1, 0.2f);
+        REQUIRE_NO_VOICES;
+    }
+
+    SECTION("allSoundsOffMatching across mono groups")
+    {
+        // Duophonic: even keys -> group 1, odd keys -> group 2, each its own mono voice
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        tp.polyGroupForKey = [](auto k) { return k % 2 == 0 ? 1 : 2; };
+        vm.setPlaymode(1, vm_t::PlayMode::MONO_NOTES, (uint64_t)MF::NATURAL_MONO);
+        vm.setPlaymode(2, vm_t::PlayMode::MONO_NOTES, (uint64_t)MF::NATURAL_MONO);
+        REQUIRE_NO_VOICES;
+
+        vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f); // group 1
+        vm.processNoteOnEvent(0, 0, 61, -1, 0.8f, 0.f); // group 2
+        REQUIRE_VOICE_COUNTS(2, 2);
+
+        // Terminate only the even-key (group 1) mono voice
+        vm.allSoundsOffMatching([](auto *v) { return v->key() % 2 == 0; });
+        REQUIRE_VOICE_COUNTS(1, 1);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 61; }) == 1);
     }
 }
 

--- a/tests/continuation_data.cpp
+++ b/tests/continuation_data.cpp
@@ -317,7 +317,7 @@ TEST_CASE("Continuation Data - Mono Retrigger Note-On Steal")
                 }) == 1);
 }
 
-TEST_CASE("Continuation Data - Mono Retrigger Note-Off Returns With Prior")
+TEST_CASE("Continuation Data - Mono Retrig Note-Off Prior Data")
 {
     INFO("When a mono note-off finds another key held, getContinuationData is called on the "
          "terminating voice before it is destroyed; the value reaches the voice that takes over");

--- a/tests/note_on_return.cpp
+++ b/tests/note_on_return.cpp
@@ -1,0 +1,147 @@
+/*
+ * sst-voicemanager - a header only library providing synth
+ * voice management in response to midi and clap event streams
+ * with support for a variety of play, trigger, and midi nodes
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-voicemanager is released under the MIT license, available
+ * as LICENSE.md in the root of this repository.
+ *
+ * All source in sst-voicemanager available at
+ * https://github.com/surge-synthesizer/sst-voicemanager
+ */
+
+#include "catch2.hpp"
+
+#include "sst/voicemanager/voicemanager.h"
+#include "test_player.h"
+
+/*
+ * processNoteOnEvent returns a bool. The contract: it returns true only when the
+ * note-on was handled by the PIANO fast-retrigger path (an existing, non-gated voice
+ * for the same key was re-gated rather than a new voice being created). Every path
+ * that runs the normal begin/init voice-creation transaction returns false - including
+ * fresh poly notes and all mono note-ons (even when the mono voice is moved or skipped).
+ */
+
+TEST_CASE("processNoteOnEvent Return - Poly")
+{
+    TestPlayer<32> tp;
+    auto &vm = tp.voiceManager;
+    REQUIRE_NO_VOICES;
+
+    // A fresh poly note creates a voice via the normal path -> false
+    REQUIRE(vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f) == false);
+    REQUIRE_VOICE_COUNTS(1, 1);
+
+    // A second, distinct poly note also goes through the normal path -> false
+    REQUIRE(vm.processNoteOnEvent(0, 0, 64, -1, 0.8f, 0.f) == false);
+    REQUIRE_VOICE_COUNTS(2, 2);
+
+    // Re-striking a still-gated key in the default MULTI_VOICE mode just makes another
+    // voice (no piano retrigger) -> false
+    REQUIRE(vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f) == false);
+    REQUIRE_VOICE_COUNTS(3, 3);
+}
+
+TEST_CASE("processNoteOnEvent Return - Piano Mode Retrigger")
+{
+    using vm_t = TestPlayer<32>::voiceManager_t;
+
+    SECTION("Retrigger Of A Releasing Key Returns True (no note id)")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        vm.repeatedKeyMode = vm_t::RepeatedKeyMode::PIANO;
+        REQUIRE_NO_VOICES;
+
+        // First strike: no voice exists yet, so this falls through to normal creation
+        REQUIRE(vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f) == false);
+        REQUIRE_VOICE_COUNTS(1, 1);
+
+        // Release it; the voice is now active but releasing (ungated)
+        vm.processNoteOffEvent(0, 0, 60, -1, 0.2f);
+        tp.processFor(1);
+        REQUIRE_VOICE_COUNTS(1, 0);
+
+        // Striking the same key while it is releasing retriggers in place -> true
+        REQUIRE(vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f) == true);
+        REQUIRE_VOICE_COUNTS(1, 1);
+    }
+
+    SECTION("Retrigger Of A Releasing Key Returns True (with note ids)")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        vm.repeatedKeyMode = vm_t::RepeatedKeyMode::PIANO;
+        REQUIRE_NO_VOICES;
+
+        REQUIRE(vm.processNoteOnEvent(0, 0, 60, 1000, 0.8f, 0.f) == false);
+        REQUIRE_VOICE_COUNTS(1, 1);
+
+        vm.processNoteOffEvent(0, 0, 60, 1000, 0.2f);
+        tp.processFor(1);
+        REQUIRE_VOICE_COUNTS(1, 0);
+
+        REQUIRE(vm.processNoteOnEvent(0, 0, 60, 1001, 0.8f, 0.f) == true);
+        REQUIRE_VOICE_COUNTS(1, 1);
+    }
+
+    SECTION("Sustained Key Retrigger Returns True")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        vm.repeatedKeyMode = vm_t::RepeatedKeyMode::PIANO;
+        REQUIRE_NO_VOICES;
+
+        REQUIRE(vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f) == false);
+        vm.updateSustainPedal(0, 0, 127);
+        vm.processNoteOffEvent(0, 0, 60, -1, 0.2f);
+        // Still gated, but only by sustain
+        REQUIRE_VOICE_COUNTS(1, 1);
+
+        // Re-striking the sustain-held key retriggers it -> true
+        REQUIRE(vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f) == true);
+        REQUIRE_VOICE_COUNTS(1, 1);
+    }
+}
+
+TEST_CASE("processNoteOnEvent Return - Mono Modes")
+{
+    using vm_t = TestPlayer<32>::voiceManager_t;
+    using MF = vm_t::MonoPlayModeFeatures;
+
+    SECTION("NATURAL_MONO Always Returns False")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        vm.setPlaymode(0, vm_t::PlayMode::MONO_NOTES, (uint64_t)MF::NATURAL_MONO);
+        REQUIRE_NO_VOICES;
+
+        // First mono note runs the normal creation path -> false
+        REQUIRE(vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f) == false);
+        REQUIRE_VOICE_COUNTS(1, 1);
+
+        // A second mono note steals/recreates through the transaction -> false
+        REQUIRE(vm.processNoteOnEvent(0, 0, 64, -1, 0.8f, 0.f) == false);
+        REQUIRE_VOICE_COUNTS(1, 1);
+    }
+
+    SECTION("NATURAL_LEGATO Always Returns False")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        vm.setPlaymode(0, vm_t::PlayMode::MONO_NOTES, (uint64_t)MF::NATURAL_LEGATO);
+        REQUIRE_NO_VOICES;
+
+        REQUIRE(vm.processNoteOnEvent(0, 0, 60, -1, 0.8f, 0.f) == false);
+        REQUIRE_VOICE_COUNTS(1, 1);
+
+        // Legato move of the existing voice still reports false (the begin/init
+        // transaction ran even though the voice was moved rather than created)
+        REQUIRE(vm.processNoteOnEvent(0, 0, 64, -1, 0.8f, 0.f) == false);
+        REQUIRE_VOICE_COUNTS(1, 1);
+    }
+}

--- a/tests/priority_mono.cpp
+++ b/tests/priority_mono.cpp
@@ -34,7 +34,7 @@
 // MONO_LEGATO + HIGHEST
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Mono Legato - Stealing Priority HIGHEST: higher note wins")
+TEST_CASE("Mono Legato - HIGHEST: higher note wins")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -58,7 +58,7 @@ TEST_CASE("Mono Legato - Stealing Priority HIGHEST: higher note wins")
     REQUIRE_VOICE_COUNTS(1, 1);
 }
 
-TEST_CASE("Mono Legato - Stealing Priority HIGHEST: lower note does not move voice")
+TEST_CASE("Mono Legato - HIGHEST: lower note does not move voice")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -84,8 +84,7 @@ TEST_CASE("Mono Legato - Stealing Priority HIGHEST: lower note does not move voi
     REQUIRE_VOICE_MATCH(1, v.key() == 65);
 }
 
-TEST_CASE(
-    "Mono Legato - Stealing Priority HIGHEST: release highest, voice moves to next-highest held")
+TEST_CASE("Mono Legato - HIGHEST: release highest, voice to next-highest held")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -122,8 +121,7 @@ TEST_CASE(
     REQUIRE_VOICE_COUNTS(0, 0);
 }
 
-TEST_CASE(
-    "Mono Legato - Stealing Priority HIGHEST: releasing non-winning note clears its held state")
+TEST_CASE("Mono Legato - HIGHEST: releasing non-winning note clears held state")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -161,7 +159,7 @@ TEST_CASE(
 // MONO_LEGATO + LOWEST
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Mono Legato - Stealing Priority LOWEST: lower note wins")
+TEST_CASE("Mono Legato - LOWEST: lower note wins")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -187,7 +185,7 @@ TEST_CASE("Mono Legato - Stealing Priority LOWEST: lower note wins")
     REQUIRE_VOICE_MATCH(1, v.key() == 60);
 }
 
-TEST_CASE("Mono Legato - Stealing Priority LOWEST: release lowest, voice moves to next-lowest held")
+TEST_CASE("Mono Legato - LOWEST: release lowest moves to next-lowest")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -228,7 +226,7 @@ TEST_CASE("Mono Legato - Stealing Priority LOWEST: release lowest, voice moves t
 // MONO_NOTES (retrigger) + HIGHEST
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Mono Retrigger - Stealing Priority HIGHEST: higher note wins")
+TEST_CASE("Mono Retrigger - HIGHEST: higher note wins")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -249,7 +247,7 @@ TEST_CASE("Mono Retrigger - Stealing Priority HIGHEST: higher note wins")
     REQUIRE_VOICE_MATCH(1, v.key() == 65);
 }
 
-TEST_CASE("Mono Retrigger - Stealing Priority HIGHEST: lower note does not retrigger")
+TEST_CASE("Mono Retrigger - HIGHEST: lower note does not retrigger")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -271,7 +269,7 @@ TEST_CASE("Mono Retrigger - Stealing Priority HIGHEST: lower note does not retri
     REQUIRE_VOICE_MATCH(1, v.key() == 65);
 }
 
-TEST_CASE("Mono Retrigger - Stealing Priority HIGHEST: release highest retrigs to held lower note")
+TEST_CASE("Mono Retrigger - HIGHEST: release high retrigs held lower")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -312,7 +310,7 @@ TEST_CASE("Mono Retrigger - Stealing Priority HIGHEST: release highest retrigs t
 // MONO_NOTES (retrigger) + LOWEST
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Mono Retrigger - Stealing Priority LOWEST: lower note wins")
+TEST_CASE("Mono Retrigger - LOWEST: lower note wins")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -338,7 +336,7 @@ TEST_CASE("Mono Retrigger - Stealing Priority LOWEST: lower note wins")
     REQUIRE_VOICE_MATCH(1, v.key() == 60);
 }
 
-TEST_CASE("Mono Retrigger - Stealing Priority LOWEST: release lowest retrigs to held higher note")
+TEST_CASE("Mono Retrigger - LOWEST: release low retrigs held higher")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -506,7 +504,7 @@ TEST_CASE("Mono Retrigger - Sustain interaction with MonoPriorityMode")
 // LATEST still works as before (regression guard)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Mono Legato - Priority LATEST: any new note always wins (default behaviour)")
+TEST_CASE("Mono Legato - LATEST: any new note always wins")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -536,7 +534,7 @@ TEST_CASE("Mono Legato - Priority LATEST: any new note always wins (default beha
     REQUIRE_VOICE_MATCH(1, v.key() == 50);
 }
 
-TEST_CASE("Mono Retrigger - Priority LATEST: any new note always retrigs (default behaviour)")
+TEST_CASE("Mono Retrigger - LATEST: any new note always retrigs")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -567,7 +565,7 @@ TEST_CASE("Mono Retrigger - Priority LATEST: any new note always retrigs (defaul
 // Same logic applies to HIGHEST mode (release 65, press 60 should win).
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Mono Legato - LOWEST: releasing voice does not block higher new note")
+TEST_CASE("Mono Legato - LOWEST: releasing does not block higher")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -593,7 +591,7 @@ TEST_CASE("Mono Legato - LOWEST: releasing voice does not block higher new note"
     REQUIRE_VOICE_MATCH(1, v.key() == 62);
 }
 
-TEST_CASE("Mono Legato - HIGHEST: releasing voice does not block lower new note")
+TEST_CASE("Mono Legato - HIGHEST: releasing does not block lower")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -619,7 +617,7 @@ TEST_CASE("Mono Legato - HIGHEST: releasing voice does not block lower new note"
     REQUIRE_VOICE_MATCH(1, v.key() == 60);
 }
 
-TEST_CASE("Mono Retrigger - LOWEST: releasing voice does not block higher new note")
+TEST_CASE("Mono Retrigger - LOWEST: releasing does not block higher")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -646,7 +644,7 @@ TEST_CASE("Mono Retrigger - LOWEST: releasing voice does not block higher new no
     REQUIRE_VOICE_MATCH(1, v.key() == 62);
 }
 
-TEST_CASE("Mono Retrigger - HIGHEST: releasing voice does not block lower new note")
+TEST_CASE("Mono Retrigger - HIGHEST: releasing does not block lower")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -681,7 +679,7 @@ TEST_CASE("Mono Retrigger - HIGHEST: releasing voice does not block lower new no
 // always win and retrigger the voice regardless of priority mode.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Mono Legato - HIGHEST: repeated note (same key) always wins")
+TEST_CASE("Mono Legato - HIGHEST: repeated key always wins")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -706,7 +704,7 @@ TEST_CASE("Mono Legato - HIGHEST: repeated note (same key) always wins")
     REQUIRE_VOICE_MATCH(1, v.key() == 60);
 }
 
-TEST_CASE("Mono Legato - LOWEST: repeated note (same key) always wins")
+TEST_CASE("Mono Legato - LOWEST: repeated key always wins")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -731,7 +729,7 @@ TEST_CASE("Mono Legato - LOWEST: repeated note (same key) always wins")
     REQUIRE_VOICE_MATCH(1, v.key() == 60);
 }
 
-TEST_CASE("Mono Retrigger - HIGHEST: repeated note (same key) always wins")
+TEST_CASE("Mono Retrigger - HIGHEST: repeated key always wins")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;
@@ -756,7 +754,7 @@ TEST_CASE("Mono Retrigger - HIGHEST: repeated note (same key) always wins")
     REQUIRE_VOICE_MATCH(1, v.key() == 60);
 }
 
-TEST_CASE("Mono Retrigger - LOWEST: repeated note (same key) always wins")
+TEST_CASE("Mono Retrigger - LOWEST: repeated key always wins")
 {
     auto tp = TestPlayer<32, false>();
     typedef TestPlayer<32, false>::voiceManager_t vm_t;

--- a/tests/stealing_groups.cpp
+++ b/tests/stealing_groups.cpp
@@ -55,6 +55,65 @@ TEST_CASE("Stealing Groups - global group")
     }
 }
 
+TEST_CASE("Voice Limit Clamping")
+{
+    SECTION("Zero Clamps To One")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+
+        vm.setPolyphonyGroupVoiceLimit(0, 0);
+        REQUIRE(vm.getPolyphonyGroupVoiceLimit(0) == 1);
+
+        // Behaviorally a limit of 1 means each new note steals the previous one
+        for (int i = 0; i < 5; ++i)
+        {
+            vm.processNoteOnEvent(0, 0, 60 + i, -1, 0.8, 0.0);
+            REQUIRE_VOICE_COUNTS(1, 1);
+        }
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 64; }) == 1);
+    }
+
+    SECTION("Negative Clamps To One")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+
+        vm.setPolyphonyGroupVoiceLimit(0, -7);
+        REQUIRE(vm.getPolyphonyGroupVoiceLimit(0) == 1);
+    }
+
+    SECTION("Above Pool Clamps To maxVoiceCount")
+    {
+        TestPlayer<8> tp;
+        auto &vm = tp.voiceManager;
+
+        vm.setPolyphonyGroupVoiceLimit(0, 9999);
+        REQUIRE(vm.getPolyphonyGroupVoiceLimit(0) == 8);
+
+        // And the group never exceeds the physical pool
+        for (int i = 0; i < 12; ++i)
+            vm.processNoteOnEvent(0, 0, 50 + i, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8);
+    }
+
+    SECTION("In-Range Limit Is Stored Verbatim")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+
+        vm.setPolyphonyGroupVoiceLimit(0, 5);
+        REQUIRE(vm.getPolyphonyGroupVoiceLimit(0) == 5);
+    }
+
+    SECTION("Unset Group Reports maxVoiceCount Default")
+    {
+        TestPlayer<16> tp;
+        auto &vm = tp.voiceManager;
+        REQUIRE(vm.getPolyphonyGroupVoiceLimit(424242) == 16);
+    }
+}
+
 TEST_CASE("Delayed Termination")
 {
     TestPlayer<32> tp;

--- a/tests/test_player.h
+++ b/tests/test_player.h
@@ -69,6 +69,7 @@ template <size_t voiceCount, bool doLog = false> struct TestPlayer
         bool slatedForTerminate{false};
 
         float velocity, releaseVelocity;
+        float retune{0.f};
 
         pckn_t pckn{-1, -1, -1, -1};
         pckn_t original_pckn{-1, -1, -1, -1};
@@ -302,6 +303,7 @@ template <size_t voiceCount, bool doLog = false> struct TestPlayer
             v->pckn = {port, channel, key, noteId};
             v->original_pckn = v->pckn;
             v->velocity = velocity;
+            v->retune = retune;
             v->creationCount = lastCreationCount++;
             v->voiceId = noteId;
             TPT("Last Creation Count is now " << lastCreationCount);


### PR DESCRIPTION
Add tests for previously-uncovered API surface: processNoteOnEvent return value (piano retrigger vs mono/poly), the retune argument, allNotesOff with sustained and mono voices, and allSoundsOff / allSoundsOffMatching in mono mode.

Voice limits below 1 or above the pool are now clamped rather than stored unchecked, with a getter added so the clamp is testable.

Also shorten over-long test and section names so they don't wrap in IDE test runners.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>