### PR TITLE
Steal excess voices when a group's limit is lowered

### DIFF
--- a/include/sst/voicemanager/voicemanager_impl.h
+++ b/include/sst/voicemanager/voicemanager_impl.h
@@ -349,6 +349,42 @@ struct VoiceManager<Cfg, Responder, MonoResponder>::Details
         return -1;
     }
 
+    // Steal up to `count` voices from a single group, using the group's stealing priority
+    // mode and keeping multi-voice notes (shared transactionId) together. Counts off a local
+    // tally rather than re-reading usedVoices, since under delayed termination the end
+    // callback (which decrements usedVoices) has not run yet.
+    void stealVoicesFromGroup(uint64_t group, int32_t count)
+    {
+        auto pm = stealingPriorityMode.at(group);
+        auto toSteal = count;
+        auto lastToSteal = toSteal + 1;
+        while (toSteal > 0 && toSteal != lastToSteal)
+        {
+            lastToSteal = toSteal;
+            auto idx = findNextStealableVoiceInfo(group, pm);
+            if (idx >= 0)
+            {
+                auto &sv = voiceInfo[idx];
+                vm.responder.terminateVoice(sv.activeVoiceCookie);
+                --toSteal;
+                for (auto &v : voiceInfo)
+                {
+                    if (v.activeVoiceCookie && v.activeVoiceCookie != sv.activeVoiceCookie &&
+                        v.transactionId == sv.transactionId)
+                    {
+                        v.alreadyStole = true;
+                        vm.responder.terminateVoice(v.activeVoiceCookie);
+                        --toSteal;
+                    }
+                }
+            }
+        }
+        // findNextStealableVoiceInfo marks alreadyStole; the note-on path clears it during
+        // placement but we have no placement, so reset it here for the next pass.
+        for (auto &v : voiceInfo)
+            v.alreadyStole = false;
+    }
+
     using continuationData_t = typename VoiceInitInstructionsEntry<Cfg>::continuationData_t;
 
     void doMonoRetrigger(int16_t port, uint64_t polyGroup,
@@ -1435,7 +1471,14 @@ void VoiceManager<Cfg, Responder, MonoResponder>::setPolyphonyGroupVoiceLimit(ui
 {
     details.guaranteeGroup(groupId);
     // A limit below 1 or above the physical pool is meaningless; clamp rather than reject
-    details.polyLimits[groupId] = std::clamp(limit, 1, static_cast<int32_t>(Cfg::maxVoiceCount));
+    auto newLimit = std::clamp(limit, 1, static_cast<int32_t>(Cfg::maxVoiceCount));
+    details.polyLimits[groupId] = newLimit;
+
+    // Lowering the limit below the group's current active count steals the excess now
+    // rather than waiting for the next note-on to enforce it.
+    auto excess = details.usedVoices.at(groupId) - newLimit;
+    if (excess > 0)
+        details.stealVoicesFromGroup(groupId, excess);
 }
 
 template <typename Cfg, typename Responder, typename MonoResponder>

--- a/tests/stealing_groups.cpp
+++ b/tests/stealing_groups.cpp
@@ -387,3 +387,98 @@ TEST_CASE("Stealing - up to physical limit with groups")
         }
     }
 }
+
+TEST_CASE("Lower Voice Limit Steals Excess")
+{
+    INFO("Lowering a group's voice limit below its active count steals the excess "
+         "immediately, using the group's stealing priority mode.");
+
+    SECTION("OLDEST default steals the oldest voices")
+    {
+        TestPlayer<32, false> tp;
+        auto &vm = tp.voiceManager;
+
+        vm.setPolyphonyGroupVoiceLimit(0, 6);
+        for (int i = 0; i < 5; ++i)
+            vm.processNoteOnEvent(0, 0, 60 + i, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(5, 5);
+
+        // Drop the limit to 3: the two oldest (keys 60, 61) are stolen
+        vm.setPolyphonyGroupVoiceLimit(0, 3);
+        REQUIRE_VOICE_COUNTS(3, 3);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() >= 62 && v.key() <= 64; }) ==
+                3);
+    }
+
+    SECTION("HIGHEST steals the highest keys")
+    {
+        TestPlayer<32, false> tp;
+        auto &vm = tp.voiceManager;
+        typedef TestPlayer<32, false>::voiceManager_t vm_t;
+
+        vm.setStealingPriorityMode(0, vm_t::StealingPriorityMode::HIGHEST);
+        for (int i = 0; i < 5; ++i)
+            vm.processNoteOnEvent(0, 0, 60 + i, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(5, 5);
+
+        // Drop to 3: the two highest (keys 64, 63) are stolen, 60..62 survive
+        vm.setPolyphonyGroupVoiceLimit(0, 3);
+        REQUIRE_VOICE_COUNTS(3, 3);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() >= 60 && v.key() <= 62; }) ==
+                3);
+    }
+
+    SECTION("Limit at or above active count steals nothing")
+    {
+        TestPlayer<32, false> tp;
+        auto &vm = tp.voiceManager;
+
+        vm.setPolyphonyGroupVoiceLimit(0, 6);
+        for (int i = 0; i < 5; ++i)
+            vm.processNoteOnEvent(0, 0, 60 + i, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(5, 5);
+
+        vm.setPolyphonyGroupVoiceLimit(0, 5);
+        REQUIRE_VOICE_COUNTS(5, 5);
+
+        // Raising the limit also leaves the voices alone
+        vm.setPolyphonyGroupVoiceLimit(0, 10);
+        REQUIRE_VOICE_COUNTS(5, 5);
+    }
+
+    SECTION("Only the targeted group is reduced")
+    {
+        TestPlayer<32, false> tp;
+        auto &vm = tp.voiceManager;
+        vm.guaranteeGroup(1);
+        tp.polyGroupForKey = [](auto k) { return (k % 2 == 0 ? 0 : 1); };
+
+        for (int i = 0; i < 8; ++i)
+            vm.processNoteOnEvent(0, 0, 60 + i, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8);
+
+        // Lower group 0 (even keys) to 2; group 1 (odd keys) is untouched
+        vm.setPolyphonyGroupVoiceLimit(0, 2);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() % 2 == 0; }) == 2);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() % 2 == 1; }) == 4);
+    }
+}
+
+TEST_CASE("Lower Voice Limit Delayed Termination")
+{
+    INFO("Under delayed termination the stolen voices are slated for terminate rather than "
+         "reaped instantly.");
+
+    TestPlayer<32, false> tp;
+    tp.terminateInstantly = false;
+    auto &vm = tp.voiceManager;
+
+    vm.setPolyphonyGroupVoiceLimit(0, 6);
+    for (int i = 0; i < 5; ++i)
+        vm.processNoteOnEvent(0, 0, 60 + i, -1, 0.8, 0.0);
+    REQUIRE_VOICE_COUNTS(5, 5);
+
+    vm.setPolyphonyGroupVoiceLimit(0, 3);
+    // The end callback has not fired, so all five slots are still counted, with two slated
+    REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.slatedForTerminate; }) == 2);
+}


### PR DESCRIPTION
Lowering a polyphony group's voice limit below its current active count now steals the excess immediately, honoring the group's stealing priority mode and keeping multi-voice notes together, rather than waiting for the next note-on to enforce the new limit.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>