### PR TITLE
Test cross-group steal priority and releasing-voice preference

### DIFF
--- a/tests/stealing_groups.cpp
+++ b/tests/stealing_groups.cpp
@@ -482,3 +482,54 @@ TEST_CASE("Lower Voice Limit Delayed Termination")
     // The end callback has not fired, so all five slots are still counted, with two slated
     REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.slatedForTerminate; }) == 2);
 }
+
+TEST_CASE("Cross-Group Steal Honors Requesting Group Priority")
+{
+    INFO("When the physical pool is full but the requesting group still has headroom, the "
+         "steal crosses groups using the REQUESTING group's stealing priority mode.");
+
+    typedef TestPlayer<8, false>::voiceManager_t vm_t;
+
+    SECTION("HIGHEST steals the highest key across all groups")
+    {
+        TestPlayer<8, false> tp;
+        auto &vm = tp.voiceManager;
+        vm.guaranteeGroup(1);
+
+        // Keys < 64 -> group 0 (the requester), keys >= 64 -> group 1 (the victim pool)
+        tp.polyGroupForKey = [](auto k) { return k < 64 ? 0 : 1; };
+        vm.setStealingPriorityMode(0, vm_t::StealingPriorityMode::HIGHEST);
+
+        for (int k : {60, 61, 62, 63, 64, 65, 66, 67})
+            vm.processNoteOnEvent(0, 0, k, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8); // pool of 8 is full
+
+        // New group-0 note: group 0 has headroom, pool is full -> steal across groups,
+        // HIGHEST -> key 67 (which lives in group 1)
+        vm.processNoteOnEvent(0, 0, 50, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 67; }) == 0);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 50; }) == 1);
+    }
+
+    SECTION("LOWEST steals the lowest key across all groups")
+    {
+        TestPlayer<8, false> tp;
+        auto &vm = tp.voiceManager;
+        vm.guaranteeGroup(1);
+
+        // Keys >= 64 -> group 0 (the requester), keys < 64 -> group 1 (the victim pool)
+        tp.polyGroupForKey = [](auto k) { return k >= 64 ? 0 : 1; };
+        vm.setStealingPriorityMode(0, vm_t::StealingPriorityMode::LOWEST);
+
+        for (int k : {60, 61, 62, 63, 64, 65, 66, 67})
+            vm.processNoteOnEvent(0, 0, k, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8);
+
+        // New group-0 note: LOWEST -> key 60 (which lives in group 1)
+        vm.processNoteOnEvent(0, 0, 70, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 60; }) == 0);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 70; }) == 1);
+    }
+}

--- a/tests/stealing_priorities.cpp
+++ b/tests/stealing_priorities.cpp
@@ -143,3 +143,41 @@ TEST_CASE("Stealing Priority - Lowest")
         }
     }
 }
+
+TEST_CASE("Stealing Prefers Releasing Voices Before Gated")
+{
+    INFO("A releasing (ungated) voice is stolen before any gated voice, regardless of the "
+         "group's stealing priority mode. The released key (62) is neither the oldest (60) "
+         "nor the highest (63), so its selection can only be the releasing-first tier.");
+
+    typedef TestPlayer<32, false>::voiceManager_t vm_t;
+
+    auto runWith = [](vm_t::StealingPriorityMode mode)
+    {
+        TestPlayer<32, false> tp;
+        auto &vm = tp.voiceManager;
+        vm.setPolyphonyGroupVoiceLimit(0, 4);
+        vm.setStealingPriorityMode(0, mode);
+
+        for (int k : {60, 61, 62, 63})
+            vm.processNoteOnEvent(0, 0, k, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(4, 4);
+
+        // Release the middle key; it is now ungated but still sounding (no processFor)
+        vm.processNoteOffEvent(0, 0, 62, -1, 0.8);
+        REQUIRE_VOICE_COUNTS(4, 3);
+
+        // A new note forces a steal. The releasing voice (62) is taken first, so the
+        // gated voices the priority mode would otherwise pick (60 or 63) survive.
+        vm.processNoteOnEvent(0, 0, 50, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(4, 4);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 62; }) == 0);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 60; }) == 1);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 63; }) == 1);
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 50; }) == 1);
+    };
+
+    SECTION("Under OLDEST priority") { runWith(vm_t::StealingPriorityMode::OLDEST); }
+    SECTION("Under HIGHEST priority") { runWith(vm_t::StealingPriorityMode::HIGHEST); }
+    SECTION("Under LOWEST priority") { runWith(vm_t::StealingPriorityMode::LOWEST); }
+}


### PR DESCRIPTION
Add coverage for two previously untested stealing dimensions: a physical-pool steal that crosses groups uses the requesting group's HIGHEST/LOWEST priority, and a releasing (ungated) voice is always stolen before a gated one regardless of priority mode.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>