### PR TITLE
Add hierarchical polyphony groups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ if (${bldtest})
             tests/mpe_tests.cpp
             tests/routing_params.cpp
             tests/stealing_groups.cpp
+            tests/hierarchical_groups.cpp
             tests/stealing_maxvoice.cpp
             tests/stealing_priorities.cpp
             tests/priority_mono.cpp

--- a/include/sst/voicemanager/voicemanager.h
+++ b/include/sst/voicemanager/voicemanager.h
@@ -245,11 +245,31 @@ template <typename Cfg, typename Responder, typename MonoResponder> struct Voice
     void allSoundsOff();
     void allSoundsOffMatching(std::function<bool(typename Cfg::voice_t *)>);
 
+    /**
+     * Pass as the parent to setPolyphonyGroupParent to detach a group, making it a root
+     * whose only super-constraint is the global voice pool.
+     */
+    static constexpr uint64_t noPolyphonyGroupParent{std::numeric_limits<uint64_t>::max()};
+
     void guaranteeGroup(uint64_t groupId);
     void setPolyphonyGroupVoiceLimit(uint64_t groupId, int32_t limit);
     [[nodiscard]] int32_t getPolyphonyGroupVoiceLimit(uint64_t groupId) const;
-    void setPlaymode(uint64_t groupId, PlayMode pm,
+
+    /**
+     * Make childGroup count its voices against parentGroup (and every ancestor above it),
+     * forming a hierarchy. A voice still belongs to exactly one group but is budgeted by
+     * the whole ancestor chain. Pass noPolyphonyGroupParent to detach. Returns false
+     * (no-op) if it would create a cycle, or if the parent is MONO (only leaf groups may
+     * be MONO).
+     */
+    bool setPolyphonyGroupParent(uint64_t childGroup, uint64_t parentGroup);
+    /**
+     * Set a group's play mode. Returns false (leaving the group unchanged) if a MONO mode
+     * is requested for a group that has children, since only leaf groups may be MONO.
+     */
+    bool setPlaymode(uint64_t groupId, PlayMode pm,
                      uint64_t features = static_cast<uint64_t>(MonoPlayModeFeatures::NONE));
+    [[nodiscard]] PlayMode getPlaymode(uint64_t groupId) const;
     void setStealingPriorityMode(uint64_t groupId, StealingPriorityMode pm);
     void setMonoPriorityMode(uint64_t groupId, MonoPriorityMode pm);
 

--- a/include/sst/voicemanager/voicemanager_impl.h
+++ b/include/sst/voicemanager/voicemanager_impl.h
@@ -151,11 +151,66 @@ struct VoiceManager<Cfg, Responder, MonoResponder>::Details
         MonoPriorityMode monoPriorityMode{MonoPriorityMode::LATEST};
         PlayMode playMode{PlayMode::POLY_VOICES};
         uint64_t playModeFeatures{static_cast<uint64_t>(MonoPlayModeFeatures::NONE)};
+        // A voice counts against this group and every ancestor up the parent chain.
+        // Default makes every new group a root, preserving flat behavior.
+        uint64_t parentGroup{noPolyphonyGroupParent};
     };
     std::unordered_map<uint64_t, GroupState> groups{};
 
     GroupState &group(uint64_t id) { return groups.at(id); }
     const GroupState &group(uint64_t id) const { return groups.at(id); }
+
+    // Walk g up the parent chain; true if ancestor is hit (g itself counts), false on
+    // reaching a root. Depth cap defends against a malformed cycle.
+    bool isDescendantOrSelf(uint64_t g, uint64_t ancestor) const
+    {
+        size_t guard{0};
+        for (uint64_t c = g; c != noPolyphonyGroupParent; c = group(c).parentGroup)
+        {
+            if (c == ancestor)
+                return true;
+            if (++guard > groups.size() + 1)
+                break;
+        }
+        return false;
+    }
+
+    // A voice in `leaf` counts against leaf and every ancestor; walk the chain applying
+    // delta to each usedVoices. Mirrors how totalUsedVoices is kept, one level up per hop.
+    void adjustSubtreeUsedVoices(uint64_t leaf, int32_t delta)
+    {
+        size_t guard{0};
+        for (uint64_t g = leaf; g != noPolyphonyGroupParent; g = group(g).parentGroup)
+        {
+            group(g).usedVoices += delta;
+            if (++guard > groups.size() + 1)
+                break;
+        }
+    }
+
+    // True if any group names groupId as its parent.
+    bool hasChildren(uint64_t groupId) const
+    {
+        for (const auto &[id, gs] : groups)
+            if (gs.parentGroup == groupId)
+                return true;
+        return false;
+    }
+
+    // Rebuild every group's subtree-inclusive usedVoices from a scan of active voices.
+    // Called after a reparent, whose effect on the subtree counts cannot be applied
+    // incrementally.
+    void recomputeUsedVoices()
+    {
+        for (auto &[id, gs] : groups)
+            gs.usedVoices = 0;
+        for (const auto &vi : voiceInfo)
+        {
+            if (!vi.activeVoiceCookie)
+                continue;
+            adjustSubtreeUsedVoices(vi.polyGroup, 1);
+        }
+    }
 
     int32_t totalUsedVoices{0};
 
@@ -224,7 +279,7 @@ struct VoiceManager<Cfg, Responder, MonoResponder>::Details
         {
             if (vi.activeVoiceCookie == v)
             {
-                --group(vi.polyGroup).usedVoices;
+                adjustSubtreeUsedVoices(vi.polyGroup, -1);
                 --totalUsedVoices;
                 VML("  - Ending voice " << vi.activeVoiceCookie << " pg=" << vi.polyGroup
                                         << " used now is " << group(vi.polyGroup).usedVoices << " ("
@@ -254,7 +309,11 @@ struct VoiceManager<Cfg, Responder, MonoResponder>::Details
             {
                 continue;
             }
-            if (v.polyGroup != polygroup && !ignorePolygroup)
+            // polygroup is a steal *scope*: a voice is eligible when its leaf group sits
+            // in that scope's subtree (so a parent scope reaches all its descendants).
+            // ignorePolygroup keeps the GLOBAL-scope "any voice" behavior. With no
+            // hierarchy this is exactly v.polyGroup == polygroup.
+            if (!ignorePolygroup && !isDescendantOrSelf(v.polyGroup, polygroup))
             {
                 continue;
             }
@@ -351,10 +410,12 @@ struct VoiceManager<Cfg, Responder, MonoResponder>::Details
         return -1;
     }
 
-    // Steal up to `count` voices from a single group, using the group's stealing priority
-    // mode and keeping multi-voice notes (shared transactionId) together. Counts off a local
-    // tally rather than re-reading usedVoices, since under delayed termination the end
-    // callback (which decrements usedVoices) has not run yet.
+    // Steal up to `count` voices from a group's subtree (findNextStealableVoiceInfo is
+    // scope-based: any voice whose leaf isDescendantOrSelf of `group` is eligible), using
+    // the group's stealing priority mode and keeping multi-voice notes (shared
+    // transactionId) together. Counts off a local tally rather than re-reading usedVoices,
+    // since under delayed termination the end callback (which decrements usedVoices) has
+    // not run yet.
     void stealVoicesFromGroup(uint64_t group, int32_t count)
     {
         auto pm = this->group(group).stealingPriorityMode;
@@ -539,7 +600,7 @@ struct VoiceManager<Cfg, Responder, MonoResponder>::Details
                         << mostRecentVoiceCounter << " at pckn=" << port << "/" << dch << "/" << dk
                         << "/" << dnid << " pg=" << vi.polyGroup);
 
-                    ++group(vi.polyGroup).usedVoices;
+                    adjustSubtreeUsedVoices(vi.polyGroup, 1);
                     ++totalUsedVoices;
 
                     --voicesLeft;
@@ -754,29 +815,48 @@ bool VoiceManager<Cfg, Responder, MonoResponder>::processNoteOnEvent(int16_t por
         VML("Poly Stealing:");
         VML("- Voice " << i << " group=" << polyGroup << " mode=" << static_cast<int>(pm));
         VML("- Checking polygroup " << polyGroup);
-        int32_t voiceLimit{details.group(polyGroup).polyLimit};
-        int32_t voicesUsed{details.group(polyGroup).usedVoices};
-        int32_t groupFreeVoices = std::max(0, voiceLimit - voicesUsed);
 
+        // Free voices is the min over polyGroup's whole ancestor chain and the global
+        // pool. The steal scope is the deepest full level on that chain (the global pool
+        // is the topmost level): a voice in its subtree decrements it and every shallower
+        // full ancestor at once, while a leaf below it is left free to grow.
         int32_t globalFreeVoices = Cfg::maxVoiceCount - details.totalUsedVoices;
-        int32_t voicesFree = std::min(groupFreeVoices, globalFreeVoices);
+        int32_t voicesFree = globalFreeVoices;
+        uint64_t stealScope{polyGroup};
+        bool stealGlobal{false};
+        bool foundFull{false};
+        for (uint64_t g = polyGroup; g != noPolyphonyGroupParent; g = details.group(g).parentGroup)
+        {
+            // Raw free can go negative under delayed termination (usedVoices outruns the
+            // limit until the end callback fires); clamp for the budget min but keep the
+            // raw sign to detect a full level.
+            int32_t gFreeRaw = details.group(g).polyLimit - details.group(g).usedVoices;
+            voicesFree = std::min(voicesFree, std::max(0, gFreeRaw));
+            if (gFreeRaw <= 0 && !foundFull)
+            {
+                stealScope = g;
+                foundFull = true;
+            }
+        }
+        if (!foundFull && globalFreeVoices <= 0)
+            stealGlobal = true;
+
         VML("- VoicesFree=" << voicesFree << " toBeCreated=" << createdByPolyGroup.at(polyGroup)
-                            << " voiceLimit=" << voiceLimit << " voicesUsed=" << voicesUsed
-                            << " groupFreeVoices=" << groupFreeVoices
+                            << " stealScope=" << stealScope << " stealGlobal=" << stealGlobal
                             << " globalFreeVoices=" << globalFreeVoices);
 
         auto voicesToSteal = std::max(createdByPolyGroup.at(polyGroup) - voicesFree, 0);
-        auto stealFromPolyGroup{polyGroup};
 
         VML("- Voices to steal is " << voicesToSteal);
         auto lastVoicesToSteal = voicesToSteal + 1;
         while (voicesToSteal > 0 && voicesToSteal != lastVoicesToSteal)
         {
             lastVoicesToSteal = voicesToSteal;
+            // Priority mode is the triggering leaf's, even when the steal scope is an
+            // ancestor (decision #1); we may switch to group(stealScope)'s mode later.
             auto stealVoiceIndex = details.findNextStealableVoiceInfo(
-                polyGroup, details.group(polyGroup).stealingPriorityMode,
-                groupFreeVoices > 0 && globalFreeVoices == 0);
-            VML("- " << voicesToSteal << " from " << stealFromPolyGroup << " stealing voice "
+                stealScope, details.group(polyGroup).stealingPriorityMode, stealGlobal);
+            VML("- " << voicesToSteal << " from " << stealScope << " stealing voice "
                      << stealVoiceIndex);
             if (stealVoiceIndex >= 0)
             {
@@ -1029,7 +1109,7 @@ bool VoiceManager<Cfg, Responder, MonoResponder>::processNoteOnEvent(int16_t por
                     << " avc=" << vi.activeVoiceCookie);
 
                 assert(details.groups.find(vi.polyGroup) != details.groups.end());
-                ++details.group(vi.polyGroup).usedVoices;
+                details.adjustSubtreeUsedVoices(vi.polyGroup, 1);
                 ++details.totalUsedVoices;
                 return true;
             }
@@ -1492,10 +1572,44 @@ VoiceManager<Cfg, Responder, MonoResponder>::getPolyphonyGroupVoiceLimit(uint64_
 }
 
 template <typename Cfg, typename Responder, typename MonoResponder>
-void VoiceManager<Cfg, Responder, MonoResponder>::setPlaymode(uint64_t groupId, PlayMode pm,
+bool VoiceManager<Cfg, Responder, MonoResponder>::setPolyphonyGroupParent(uint64_t childGroup,
+                                                                          uint64_t parentGroupId)
+{
+    details.guaranteeGroup(childGroup);
+
+    if (parentGroupId == noPolyphonyGroupParent)
+    {
+        details.group(childGroup).parentGroup = noPolyphonyGroupParent;
+        details.recomputeUsedVoices();
+        return true;
+    }
+
+    details.guaranteeGroup(parentGroupId);
+
+    // Reject a cycle: parentGroupId may not already sit in childGroup's subtree
+    // (childGroup == parentGroupId is the self-parent case and is caught here too).
+    if (details.isDescendantOrSelf(parentGroupId, childGroup))
+        return false;
+
+    // Only leaf groups may be MONO; a parent must be POLY.
+    if (details.group(parentGroupId).playMode != PlayMode::POLY_VOICES)
+        return false;
+
+    details.group(childGroup).parentGroup = parentGroupId;
+    details.recomputeUsedVoices();
+    return true;
+}
+
+template <typename Cfg, typename Responder, typename MonoResponder>
+bool VoiceManager<Cfg, Responder, MonoResponder>::setPlaymode(uint64_t groupId, PlayMode pm,
                                                               uint64_t features)
 {
     details.guaranteeGroup(groupId);
+
+    // Only leaf groups may be MONO; a group with children must stay POLY so the mono
+    // machinery (which keys on a voice's exact leaf group) never silently no-ops.
+    if (pm != PlayMode::POLY_VOICES && details.hasChildren(groupId))
+        return false;
 
     // Changing the play mode or features of a group while voices are sounding leaves
     // those voices in a mode they were not started under. Rather than try to reconcile,
@@ -1522,6 +1636,17 @@ void VoiceManager<Cfg, Responder, MonoResponder>::setPlaymode(uint64_t groupId, 
 
     details.group(groupId).playMode = pm;
     details.group(groupId).playModeFeatures = features;
+    return true;
+}
+
+template <typename Cfg, typename Responder, typename MonoResponder>
+typename VoiceManager<Cfg, Responder, MonoResponder>::PlayMode
+VoiceManager<Cfg, Responder, MonoResponder>::getPlaymode(uint64_t groupId) const
+{
+    auto it = details.groups.find(groupId);
+    if (it == details.groups.end())
+        return PlayMode::POLY_VOICES;
+    return it->second.playMode;
 }
 
 template <typename Cfg, typename Responder, typename MonoResponder>

--- a/tests/hierarchical_groups.cpp
+++ b/tests/hierarchical_groups.cpp
@@ -1,0 +1,336 @@
+/*
+ * sst-voicemanager - a header only library providing synth
+ * voice management in response to midi and clap event streams
+ * with support for a variety of play, trigger, and midi nodes
+ *
+ * Copyright 2023-2024, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-voicemanager is released under the MIT license, available
+ * as LICENSE.md in the root of this repository.
+ *
+ * All source in sst-voicemanager available at
+ * https://github.com/surge-synthesizer/sst-voicemanager
+ */
+
+#include "catch2.hpp"
+
+#include "sst/voicemanager/voicemanager.h"
+#include "test_player.h"
+
+namespace
+{
+// Group ids: parent G holds children A, B, C. Keys are routed to a child by range so a
+// voice's child is identifiable from its key.
+constexpr uint64_t G{100}, A{1979}, B{21121984}, C{8675309};
+
+auto inA = [](const auto &v) { return v.key() >= 10 && v.key() < 20; };
+auto inB = [](const auto &v) { return v.key() >= 20 && v.key() < 30; };
+auto inC = [](const auto &v) { return v.key() >= 30 && v.key() < 40; };
+
+template <typename TP> void routeChildrenByKey(TP &tp)
+{
+    tp.polyGroupForKey = [](int16_t k) -> uint64_t
+    {
+        if (k >= 10 && k < 20)
+            return A;
+        if (k >= 20 && k < 30)
+            return B;
+        if (k >= 30 && k < 40)
+            return C;
+        return 0;
+    };
+}
+
+// Parent G=8 over three children A/B/C=6 (3x6=18 overcommit is legal).
+template <typename TP> void makeOvercommitTree(TP &tp)
+{
+    auto &vm = tp.voiceManager;
+    vm.setPolyphonyGroupVoiceLimit(A, 6);
+    vm.setPolyphonyGroupVoiceLimit(B, 6);
+    vm.setPolyphonyGroupVoiceLimit(C, 6);
+    vm.setPolyphonyGroupVoiceLimit(G, 8);
+    vm.setPolyphonyGroupParent(A, G);
+    vm.setPolyphonyGroupParent(B, G);
+    vm.setPolyphonyGroupParent(C, G);
+    routeChildrenByKey(tp);
+}
+} // namespace
+
+TEST_CASE("Hierarchy - parent caps the subtree")
+{
+    SECTION("Overcommit configures with no pre-steal")
+    {
+        TestPlayer<64> tp;
+        auto &vm = tp.voiceManager;
+        makeOvercommitTree(tp);
+
+        // 3x6 = 18 > 8 is legal; nothing is stolen at configure time.
+        REQUIRE_NO_VOICES;
+
+        // Fill A to its own limit 6 - parent G binds at 8, but A alone is only 6 so all land.
+        for (int i = 0; i < 6; ++i)
+            vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(6, 6);
+        REQUIRE(tp.activeVoicesMatching(inA) == 6);
+    }
+
+    SECTION("9th voice steals to hold the parent at 8, leaf grows")
+    {
+        TestPlayer<64> tp;
+        auto &vm = tp.voiceManager;
+        makeOvercommitTree(tp);
+
+        // 4 in A (keys 10-13), 2 in B (20-21), 2 in C (30-31): parent exactly full at 8.
+        for (int i = 0; i < 4; ++i)
+            vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+        for (int i = 0; i < 2; ++i)
+            vm.processNoteOnEvent(0, 0, 20 + i, -1, 0.8, 0.0);
+        for (int i = 0; i < 2; ++i)
+            vm.processNoteOnEvent(0, 0, 30 + i, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8);
+        REQUIRE(tp.activeVoicesMatching(inA) == 4);
+
+        // 9th note into C: C is 2/6 (not full), G is 8/8 (full) -> steal oldest in G's
+        // subtree (the very first note, key 10 in A), and C grows to 3. Total stays 8.
+        vm.processNoteOnEvent(0, 0, 32, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8);
+        REQUIRE(tp.activeVoicesMatching(inA) == 3); // lost its oldest
+        REQUIRE(tp.activeVoicesMatching(inB) == 2);
+        REQUIRE(tp.activeVoicesMatching(inC) == 3); // grew
+        REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 10; }) == 0);
+    }
+
+    SECTION("Note into an empty child steals from a full sibling, not itself")
+    {
+        TestPlayer<64> tp;
+        auto &vm = tp.voiceManager;
+        makeOvercommitTree(tp);
+
+        // 4 in A, 4 in B = parent full at 8; C empty.
+        for (int i = 0; i < 4; ++i)
+            vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+        for (int i = 0; i < 4; ++i)
+            vm.processNoteOnEvent(0, 0, 20 + i, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8);
+
+        // Note into empty C: steal oldest in G (key 10, in A); C becomes 1.
+        vm.processNoteOnEvent(0, 0, 30, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(8, 8);
+        REQUIRE(tp.activeVoicesMatching(inA) == 3);
+        REQUIRE(tp.activeVoicesMatching(inB) == 4);
+        REQUIRE(tp.activeVoicesMatching(inC) == 1);
+    }
+}
+
+TEST_CASE("Hierarchy - a full leaf sheds its own voice")
+{
+    TestPlayer<64> tp;
+    auto &vm = tp.voiceManager;
+    // Parent G=8, children A/B=6. Fill A to its own limit 6 (parent only 6/8).
+    vm.setPolyphonyGroupVoiceLimit(A, 6);
+    vm.setPolyphonyGroupVoiceLimit(B, 6);
+    vm.setPolyphonyGroupVoiceLimit(G, 8);
+    vm.setPolyphonyGroupParent(A, G);
+    vm.setPolyphonyGroupParent(B, G);
+    routeChildrenByKey(tp);
+
+    for (int i = 0; i < 6; ++i)
+        vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+    REQUIRE(tp.activeVoicesMatching(inA) == 6);
+
+    // 7th into A: A is the deepest full level (6/6) while G is 6/8 - steal A's own oldest.
+    vm.processNoteOnEvent(0, 0, 16, -1, 0.8, 0.0);
+    REQUIRE(tp.activeVoicesMatching(inA) == 6);
+    REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 10; }) == 0); // own oldest
+    REQUIRE_VOICE_COUNTS(6, 6);
+
+    // 1st into sibling B: G has room (6/8), B empty - no steal.
+    vm.processNoteOnEvent(0, 0, 20, -1, 0.8, 0.0);
+    REQUIRE(tp.activeVoicesMatching(inA) == 6);
+    REQUIRE(tp.activeVoicesMatching(inB) == 1);
+    REQUIRE_VOICE_COUNTS(7, 7);
+}
+
+TEST_CASE("Hierarchy - grandparent binds (depth 3)")
+{
+    // G1 (leaf) -> G2 -> G3, limits 8 / 8 / 4. The grandparent G3 caps the subtree at 4.
+    constexpr uint64_t G1{11}, G2{12}, G3{13};
+    TestPlayer<64> tp;
+    auto &vm = tp.voiceManager;
+    vm.setPolyphonyGroupVoiceLimit(G1, 8);
+    vm.setPolyphonyGroupVoiceLimit(G2, 8);
+    vm.setPolyphonyGroupVoiceLimit(G3, 4);
+    vm.setPolyphonyGroupParent(G1, G2);
+    vm.setPolyphonyGroupParent(G2, G3);
+    tp.polyGroupForKey = [](int16_t) -> uint64_t { return G1; };
+
+    for (int i = 0; i < 8; ++i)
+        vm.processNoteOnEvent(0, 0, 40 + i, -1, 0.8, 0.0);
+    // Even though G1/G2 allow 8, the grandparent G3=4 caps it.
+    REQUIRE_VOICE_COUNTS(4, 4);
+    // The four survivors are the four most recent (older ones stolen as G3 stayed full).
+    REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() >= 44; }) == 4);
+}
+
+TEST_CASE("Hierarchy - lowering a parent limit sheds across the subtree")
+{
+    TestPlayer<32> tp;
+    auto &vm = tp.voiceManager;
+    makeOvercommitTree(tp);
+
+    // 4/2/2 across A/B/C, parent full at 8.
+    for (int i = 0; i < 4; ++i)
+        vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+    for (int i = 0; i < 2; ++i)
+        vm.processNoteOnEvent(0, 0, 20 + i, -1, 0.8, 0.0);
+    for (int i = 0; i < 2; ++i)
+        vm.processNoteOnEvent(0, 0, 30 + i, -1, 0.8, 0.0);
+    REQUIRE_VOICE_COUNTS(8, 8);
+
+    // Lower G to 5: excess 3 stolen from the subtree, oldest first (keys 10,11,12 in A).
+    vm.setPolyphonyGroupVoiceLimit(G, 5);
+    REQUIRE_VOICE_COUNTS(5, 5);
+    REQUIRE(tp.activeVoicesMatching(inA) == 1); // 4 -> 1
+    REQUIRE(tp.activeVoicesMatching(inB) == 2);
+    REQUIRE(tp.activeVoicesMatching(inC) == 2);
+    REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 13; }) == 1); // newest A kept
+}
+
+TEST_CASE("Hierarchy - multi-voice note stolen as a unit under a tight parent")
+{
+    // Keys > 72 create 3 voices each. Parent G=6 over child A; two 3-voice notes fill it,
+    // a third must steal the oldest 3-voice note as a group.
+    TestPlayer<64> tp;
+    auto &vm = tp.voiceManager;
+    vm.setPolyphonyGroupVoiceLimit(A, 12);
+    vm.setPolyphonyGroupVoiceLimit(G, 6);
+    vm.setPolyphonyGroupParent(A, G);
+    tp.polyGroupForKey = [](int16_t) -> uint64_t { return A; };
+
+    vm.processNoteOnEvent(0, 0, 90, -1, 0.8, 0.0);
+    REQUIRE_VOICE_COUNTS(3, 3);
+    vm.processNoteOnEvent(0, 0, 91, -1, 0.8, 0.0);
+    REQUIRE_VOICE_COUNTS(6, 6);
+
+    // Parent full at 6; a third 3-voice note steals the first note's 3 voices together.
+    vm.processNoteOnEvent(0, 0, 92, -1, 0.8, 0.0);
+    REQUIRE_VOICE_COUNTS(6, 6);
+    REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 90; }) == 0);
+    REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 92; }) == 3);
+}
+
+TEST_CASE("Hierarchy - reparenting with live voices recomputes subtree counts")
+{
+    TestPlayer<64> tp;
+    auto &vm = tp.voiceManager;
+    vm.setPolyphonyGroupVoiceLimit(A, 6);
+    vm.setPolyphonyGroupVoiceLimit(B, 6);
+    routeChildrenByKey(tp);
+
+    // A and B are roots; put 3 live voices in A before any parent exists.
+    for (int i = 0; i < 3; ++i)
+        vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+    REQUIRE(tp.activeVoicesMatching(inA) == 3);
+
+    // Now introduce a tight parent and adopt both children while A's voices are sounding.
+    // The recompute on reparent must credit those 3 voices to G; if it did not, G would
+    // read 0 and wrongly admit 5 more (total 8) instead of capping the subtree at 5.
+    vm.setPolyphonyGroupVoiceLimit(G, 5);
+    vm.setPolyphonyGroupParent(A, G);
+    vm.setPolyphonyGroupParent(B, G);
+
+    // Fill B: subtree climbs 3 -> 5, then holds at 5, shedding A's oldest first.
+    for (int i = 0; i < 4; ++i)
+        vm.processNoteOnEvent(0, 0, 20 + i, -1, 0.8, 0.0);
+
+    REQUIRE_VOICE_COUNTS(5, 5);
+    REQUIRE(tp.activeVoicesMatching(inB) == 4);
+    REQUIRE(tp.activeVoicesMatching(inA) == 1);
+    // The survivor in A is its newest; the two oldest (keys 10, 11) were stolen.
+    REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 12; }) == 1);
+    REQUIRE(tp.activeVoicesMatching([](auto &v) { return v.key() == 10; }) == 0);
+}
+
+TEST_CASE("Hierarchy - only leaf groups may be MONO")
+{
+    using VM = TestPlayer<32>::voiceManager_t;
+
+    SECTION("Setting MONO on a group with children is rejected")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        REQUIRE(vm.setPolyphonyGroupParent(A, G)); // G now has a child
+        REQUIRE(vm.getPlaymode(G) == VM::PlayMode::POLY_VOICES);
+
+        REQUIRE_FALSE(vm.setPlaymode(G, VM::PlayMode::MONO_NOTES)); // rejected
+        REQUIRE(vm.getPlaymode(G) == VM::PlayMode::POLY_VOICES);    // unchanged
+
+        // A leaf, by contrast, takes the mode and returns true.
+        REQUIRE(vm.setPlaymode(A, VM::PlayMode::MONO_NOTES));
+        REQUIRE(vm.getPlaymode(A) == VM::PlayMode::MONO_NOTES);
+    }
+
+    SECTION("Attaching a child to a MONO group is rejected")
+    {
+        TestPlayer<32> tp;
+        auto &vm = tp.voiceManager;
+        // Parent candidate P is MONO with a tight limit; child routes here if attached.
+        vm.setPolyphonyGroupVoiceLimit(G, 2);
+        REQUIRE(vm.setPlaymode(G, VM::PlayMode::MONO_NOTES)); // G is a leaf here: allowed
+        vm.setPolyphonyGroupVoiceLimit(A, 10);
+        tp.polyGroupForKey = [](int16_t) -> uint64_t { return A; };
+
+        REQUIRE_FALSE(vm.setPolyphonyGroupParent(A, G)); // rejected: G is MONO
+
+        // A is unparented, so it fills to its own limit, not the (would-be) parent's 2.
+        for (int i = 0; i < 5; ++i)
+            vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+        REQUIRE_VOICE_COUNTS(5, 5);
+    }
+}
+
+TEST_CASE("Hierarchy - cycles and self-parent are rejected")
+{
+    TestPlayer<32> tp;
+    auto &vm = tp.voiceManager;
+    vm.setPolyphonyGroupVoiceLimit(A, 4);
+    vm.setPolyphonyGroupVoiceLimit(B, 8);
+    REQUIRE(vm.setPolyphonyGroupParent(A, B)); // A under B
+
+    // Self-parent is rejected (would be a 1-cycle).
+    REQUIRE_FALSE(vm.setPolyphonyGroupParent(A, A));
+    // Closing the loop B -> A is rejected (A is already an ancestor-or-self of B's target).
+    REQUIRE_FALSE(vm.setPolyphonyGroupParent(B, A));
+
+    // B is still a root: route to A, fill past A's limit; the binding constraint is A=4,
+    // never an accidental cycle (which would hang or miscount).
+    tp.polyGroupForKey = [](int16_t) -> uint64_t { return A; };
+    for (int i = 0; i < 7; ++i)
+        vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+    REQUIRE_VOICE_COUNTS(4, 4);
+}
+
+TEST_CASE("Hierarchy - detaching restores root behavior")
+{
+    TestPlayer<64> tp;
+    auto &vm = tp.voiceManager;
+    vm.setPolyphonyGroupVoiceLimit(A, 6);
+    vm.setPolyphonyGroupVoiceLimit(G, 3);
+    REQUIRE(vm.setPolyphonyGroupParent(A, G));
+    tp.polyGroupForKey = [](int16_t) -> uint64_t { return A; };
+
+    // Parented: A is capped by G=3.
+    for (int i = 0; i < 6; ++i)
+        vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+    REQUIRE_VOICE_COUNTS(3, 3);
+
+    vm.allSoundsOff();
+    REQUIRE_NO_VOICES;
+
+    // Detach: A is a root again, capped only by its own limit 6.
+    REQUIRE(vm.setPolyphonyGroupParent(A, TestPlayer<64>::voiceManager_t::noPolyphonyGroupParent));
+    for (int i = 0; i < 8; ++i)
+        vm.processNoteOnEvent(0, 0, 10 + i, -1, 0.8, 0.0);
+    REQUIRE_VOICE_COUNTS(6, 6);
+}


### PR DESCRIPTION
A polyphony group can now name a parent, so a voice counts against its own group and every ancestor up the chain. A group is full when its whole subtree reaches its limit, and a note-on or a lowered limit steals within the subtree of the deepest full level - letting an under-limit leaf grow by stealing a sibling while a full leaf sheds its own. With no parent configured every group is a root and behavior is unchanged.

Only leaf groups may be MONO; setPolyphonyGroupParent and setPlaymode return false when a change would form a cycle, attach under a MONO parent, or make a group with children MONO. Adds getPlaymode and tests covering the budget, stealing, depth, reparent-recompute, enforcement, and return-code behavior.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>